### PR TITLE
bugfix/put-events-reverse-chron-order

### DIFF
--- a/templates/events.html
+++ b/templates/events.html
@@ -15,7 +15,7 @@
       {% set_global years = years | concat(with= current_year[0]) | unique %}
       {% endfor %}
 
-      {% for current_year in years %}
+      {% for current_year in years | reverse %}
       <h2 class="title is-3 mb-3">{{ current_year }}</h2>
       {% for page in section.pages | sort(attribute="extra.event.date") | reverse %}
 


### PR DESCRIPTION
Fixed the events page so the years are in reverse chronological order.

The benefit of this PR cannot be seen until #12 is merged. But the events page looks like this. After this goes through, 2024 should be above 2023.

![image](https://github.com/Socal-Nix-User-Group/socal-nug/assets/7043297/580c23d1-4b2f-4269-8fa4-c3540b87dbc5)
