### PR TITLE
bugfix/fix-event-time-rendering

### DIFF
--- a/content/events/2024-01-25.md
+++ b/content/events/2024-01-25.md
@@ -6,6 +6,7 @@ organizer = "Socal NUG Organizers"
 [extra.event]
 date = "2024-01-25"
 start_time = "19:00"
+stop_time = "22:00"
 [extra.venue]
 name = "Aragon Community Rec Area"
 address_street="3000 E 19th St"

--- a/templates/partials/events.rsvp-card.html
+++ b/templates/partials/events.rsvp-card.html
@@ -18,8 +18,11 @@
                             day=date_parts[2] | int)
                         }}
                         <br>
-                        {% if 'event_start_time' in page.extra %}
-                            {{ page.extra['event_start_time'] }}
+                        {% if 'start_time' in page.extra.event %}
+                            {{ page.extra.event['start_time'] }}
+                        {% endif %}
+                        {% if 'stop_time' in page.extra.event %}
+                            - {{ page.extra.event['stop_time'] }}
                         {% endif %}
                     </time>
                 </div>


### PR DESCRIPTION
Fixed the rendering for event start times
Added an event stop time field.
Updated the most recent event meta.

![image](https://github.com/Socal-Nix-User-Group/socal-nug/assets/7043297/92a98e3b-6557-4224-8b64-c3ff875f294b)
