### PR TITLE
bugfix/show next event on homepage

### DIFF
--- a/templates/partials/home.hero.event-highlight.html
+++ b/templates/partials/home.hero.event-highlight.html
@@ -86,7 +86,7 @@
 
     const upcomingEvents = events.filter( e => e.eventDate > new Date())
     if (upcomingEvents.length > 0) {
-      displayEventBadge(upcomingEvents[0]);
+      displayEventBadge(upcomingEvents.pop());
     } 
   }());
 </script>


### PR DESCRIPTION
Fixes the event card on the home page by popping the last event from the array rather than grabbing the first.

The issue is that currently the event furthest in the future is grabbed (index 0) from the future events list. By using `pop()`, it will instead return the next future event. This only is a problem when we have more than 1 future event scheduled. But since #26 adds two, it shows the event in June rather than the event in April. This should fix that.