### PR TITLE
Fix style for the about page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -15,7 +15,7 @@
   <div class="columns is-flex-wrap-wrap is-mobile">
     {% set profiles = section.pages %}
     {% for profile in profiles %}
-    <div class="column is-one-halfvv-tablet is-full-mobile">
+    <div class="column is-half-desktop is-full-mobile">
       <div class="media">
         <div class="media-left">
           <figure>


### PR DESCRIPTION
Fixes page so it displays half-width profiles on desktop, full on mobile 

![image](https://github.com/Socal-Nix-User-Group/socal-nug/assets/477742/74bb561d-c3f8-4de9-b853-397fce672049)
